### PR TITLE
Update dependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -32,12 +32,12 @@ const [input] = cli.input;
 function init(data) {
 	try {
 		termImg(data, cli.flags);
-	} catch (err) {
-		if (err.name === 'UnsupportedTerminalError') {
-			console.error(err.message);
+	} catch (error) {
+		if (error.name === 'UnsupportedTerminalError') {
+			console.error(error.message);
 			process.exit(1);
 		} else {
-			throw err;
+			throw error;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
 	"dependencies": {
 		"get-stdin": "^6.0.0",
 		"meow": "^5.0.0",
-		"term-img": "^2.0.0"
+		"term-img": "^4.0.0"
 	},
 	"devDependencies": {
-		"ava": "*",
-		"execa": "^0.10.0",
-		"xo": "*"
+		"ava": "^0.25.0",
+		"execa": "^1.0.0",
+		"xo": "^0.23.0"
 	}
 }


### PR DESCRIPTION
- Update `term-img` to `v4.0.0`
- Update `devDependencies` (`ava`, `execa` & `xo`) to their latest version
- Update tests

Closes #2